### PR TITLE
Issue#95: Add Game Restart on Game End for Game

### DIFF
--- a/src/components/GamePages/cardSelection.jsx
+++ b/src/components/GamePages/cardSelection.jsx
@@ -18,7 +18,7 @@ class CardSelection extends React.Component {
 
   componentDidMount() {
     const { id, gameId } = this.state
-    var url = `http://localhost:3000/games/${gameId}/player_games/${id}`
+    var url = `http://localhost:3000/games/${gameId}/player_sessions/${id}`
     var data = getDataFromServer(url)
 
     data.then(response => {
@@ -31,9 +31,9 @@ class CardSelection extends React.Component {
   onFormSubmit(e) {
     e.preventDefault()
     const {id, gameId} = this.state
-    var url = `http://localhost:3000/games/${gameId}/player_games/${id}/cards`
+    var url = `http://localhost:3000/games/${gameId}/player_sessions/${id}/cards`
     var body = {
-      player_game_id: this.state.id,
+      player_session_id: this.state.id,
       card1_suit: this.state.suit1,
       card1_value: this.state.value1,
       card2_suit: this.state.suit2,

--- a/src/components/GamePages/game.jsx
+++ b/src/components/GamePages/game.jsx
@@ -335,10 +335,14 @@ class Game extends React.Component {
   }
 
   showOwnCards(player) {
+    const { joining_players } = this.state
     let cardsSpanId = `${player.seat_number}_cardsSpan`
     if ( document.getElementById(cardsSpanId) === null ) {
-      var player_game = getDataFromServer(
-        `http://localhost:3000/games/${this.state.id}/player_games/${player.player_game_id}`
+      const joined_player = joining_players.find((joining_player) => {
+        return joining_player.player_id === player.player_id
+      })
+      const player_session = getDataFromServer(
+        `http://localhost:3000/games/${this.state.id}/player_sessions/${joined_player.id}`
       )
 
       let seatPosition = document.getElementById(`seat_number_${player.seat_number}`)
@@ -348,13 +352,13 @@ class Game extends React.Component {
       cardsSpan.setAttribute("id", cardsSpanId)
       seatSpan.parentNode.insertBefore(cardsSpan, seatSpan.nextSibling)
 
-      /* player_game.then(result => result.cards.map( (card, i) =>{
-       *     let cardSpan = document.createElement("a")
-       *     cardSpan.setAttribute("class", `card_${player.seat_number}_${i+1}`)
-       *     cardSpan.textContent = parseCards(card.number, card.suit)
-       *     cardsSpan.append(cardSpan)
-       *   })
-       * ) */
+      player_session.then(result => result.cards.map( (card, i) =>{
+        let cardSpan = document.createElement("a")
+        cardSpan.setAttribute("class", `card_${player.seat_number}_${i+1}`)
+        cardSpan.textContent = parseCards(card.number, card.suit)
+        cardsSpan.append(cardSpan)
+      })
+      )
     }
   }
 

--- a/src/components/GamePages/game.jsx
+++ b/src/components/GamePages/game.jsx
@@ -341,6 +341,11 @@ class Game extends React.Component {
       const joined_player = joining_players.find((joining_player) => {
         return joining_player.player_id === player.player_id
       })
+
+      if (!joined_player) {
+        return;
+      }
+
       const player_session = getDataFromServer(
         `http://localhost:3000/games/${this.state.id}/player_sessions/${joined_player.id}`
       )

--- a/src/components/GamePages/game.jsx
+++ b/src/components/GamePages/game.jsx
@@ -26,6 +26,7 @@ class Game extends React.Component {
       game_name: null,
       community_card_modal: "",
       joining_players: [],
+      joining_players_count: 0,
       players: [],
       current_logs: "",
       communityCards: {}

--- a/src/components/GamePages/game.jsx
+++ b/src/components/GamePages/game.jsx
@@ -138,7 +138,7 @@ class Game extends React.Component {
   }
 
   willUpdateStateData(data) {
-    return data.joining_players ||
+    return data.joining_players_count ||
            data.showCardSelectionScreen ||
            data.button ||
            data.action_type === 'new_round_start'
@@ -347,13 +347,13 @@ class Game extends React.Component {
       cardsSpan.setAttribute("id", cardsSpanId)
       seatSpan.parentNode.insertBefore(cardsSpan, seatSpan.nextSibling)
 
-      player_game.then(result => result.cards.map( (card, i) =>{
-          let cardSpan = document.createElement("a")
-          cardSpan.setAttribute("class", `card_${player.seat_number}_${i+1}`)
-          cardSpan.textContent = parseCards(card.number, card.suit)
-          cardsSpan.append(cardSpan)
-        })
-      )
+      /* player_game.then(result => result.cards.map( (card, i) =>{
+       *     let cardSpan = document.createElement("a")
+       *     cardSpan.setAttribute("class", `card_${player.seat_number}_${i+1}`)
+       *     cardSpan.textContent = parseCards(card.number, card.suit)
+       *     cardsSpan.append(cardSpan)
+       *   })
+       * ) */
     }
   }
 
@@ -429,8 +429,9 @@ class Game extends React.Component {
         `http://localhost:3000/games/${this.state.id}/request_game_start`
       )
       setTimeout(() => {
-        const {joining_players} = this.state
-        if (joining_players.length < 2) {
+        const {joining_players_count} = this.state
+        console.log(joining_players_count)
+        if (joining_players_count < 2) {
           getDataFromServer(
             `http://localhost:3000/games/${this.state.id}/reset_game_start_request`
           )
@@ -440,10 +441,8 @@ class Game extends React.Component {
             {
               game_is_active: true,
               change_button: true,
-              joining_players: joining_players
             }
           ).then(result => {
-            console.log(result)
             this.initializeGameCard(result.game_sessions[0].community_card.id)
           })
         }

--- a/src/components/GamePages/game.jsx
+++ b/src/components/GamePages/game.jsx
@@ -351,8 +351,8 @@ class Game extends React.Component {
       return;
     }
 
-    const player_session = getDataFromServer(
-      `http://localhost:3000/games/${this.state.id}/player_sessions/${joined_player.id}`
+    const game = getDataFromServer(
+      `http://localhost:3000/games/${this.state.id}/`
     )
 
     let seatPosition = document.getElementById(`seat_number_${player.seat_number}`)
@@ -362,16 +362,18 @@ class Game extends React.Component {
     cardsSpan.setAttribute("id", cardsSpanId)
     seatSpan.parentNode.insertBefore(cardsSpan, seatSpan.nextSibling)
 
-    player_session.then(result => {
-      if (result.cards) {
-        result.cards.map( (card, i) =>{
+    game.then(
+      result => {
+        result.joining_players.find(player => {
+          return player.player_id === player.player_id
+        }).cards.map( (card, i) =>{
           let cardSpan = document.createElement("a")
           cardSpan.setAttribute("class", `card_${player.seat_number}_${i+1}`)
           cardSpan.textContent = parseCards(card.number, card.suit)
           cardsSpan.append(cardSpan)
         })
       }
-    })
+    )
   }
 
   handleWaitinglistRedirection(e) {

--- a/src/components/GamePages/game.jsx
+++ b/src/components/GamePages/game.jsx
@@ -54,7 +54,6 @@ class Game extends React.Component {
       button.addEventListener('click', this.handleSeatSelection.bind(this))
     })
 
-
     this.handleCurrentSeatAssignments()
     this.getCurrentComCards()
     this.createSocket()
@@ -337,34 +336,41 @@ class Game extends React.Component {
   showOwnCards(player) {
     const { joining_players } = this.state
     let cardsSpanId = `${player.seat_number}_cardsSpan`
-    if ( document.getElementById(cardsSpanId) === null ) {
-      const joined_player = joining_players.find((joining_player) => {
-        return joining_player.player_id === player.player_id
-      })
+    let currentCardsSpan = document.getElementById(cardsSpanId)
 
-      if (!joined_player) {
-        return;
-      }
-
-      const player_session = getDataFromServer(
-        `http://localhost:3000/games/${this.state.id}/player_sessions/${joined_player.id}`
-      )
-
-      let seatPosition = document.getElementById(`seat_number_${player.seat_number}`)
-      let seatSpan = seatPosition.nextSibling
-
-      let cardsSpan = document.createElement('span')
-      cardsSpan.setAttribute("id", cardsSpanId)
-      seatSpan.parentNode.insertBefore(cardsSpan, seatSpan.nextSibling)
-
-      player_session.then(result => result.cards.map( (card, i) =>{
-        let cardSpan = document.createElement("a")
-        cardSpan.setAttribute("class", `card_${player.seat_number}_${i+1}`)
-        cardSpan.textContent = parseCards(card.number, card.suit)
-        cardsSpan.append(cardSpan)
-      })
-      )
+    if (currentCardsSpan) {
+      currentCardsSpan.parentNode.removeChild(currentCardsSpan)
     }
+
+    const joined_player = joining_players.find((joining_player) => {
+      return joining_player.player_id === player.player_id
+    })
+
+    if (!joined_player) {
+      return;
+    }
+
+    const player_session = getDataFromServer(
+      `http://localhost:3000/games/${this.state.id}/player_sessions/${joined_player.id}`
+    )
+
+    let seatPosition = document.getElementById(`seat_number_${player.seat_number}`)
+    let seatSpan = seatPosition.nextSibling
+
+    let cardsSpan = document.createElement('span')
+    cardsSpan.setAttribute("id", cardsSpanId)
+    seatSpan.parentNode.insertBefore(cardsSpan, seatSpan.nextSibling)
+
+    player_session.then(result => {
+      if (result.cards) {
+        result.cards.map( (card, i) =>{
+          let cardSpan = document.createElement("a")
+          cardSpan.setAttribute("class", `card_${player.seat_number}_${i+1}`)
+          cardSpan.textContent = parseCards(card.number, card.suit)
+          cardsSpan.append(cardSpan)
+        })
+      }
+    })
   }
 
   handleWaitinglistRedirection(e) {

--- a/src/components/GamePages/game.jsx
+++ b/src/components/GamePages/game.jsx
@@ -364,14 +364,15 @@ class Game extends React.Component {
 
     game.then(
       result => {
-        result.joining_players.find(player => {
-          return player.player_id === player.player_id
-        }).cards.map( (card, i) =>{
-          let cardSpan = document.createElement("a")
-          cardSpan.setAttribute("class", `card_${player.seat_number}_${i+1}`)
-          cardSpan.textContent = parseCards(card.number, card.suit)
-          cardsSpan.append(cardSpan)
-        })
+        let this_joining_player = result.joining_players.find(joining_player => { return joining_player.player_id === player.player_id })
+        if (this_joining_player && this_joining_player.cards) {
+          this_joining_player.cards.map( (card, i) =>{
+            let cardSpan = document.createElement("a")
+            cardSpan.setAttribute("class", `card_${player.seat_number}_${i+1}`)
+            cardSpan.textContent = parseCards(card.number, card.suit)
+            cardsSpan.append(cardSpan)
+          })
+        }
       }
     )
   }

--- a/src/components/GamePages/game.jsx
+++ b/src/components/GamePages/game.jsx
@@ -139,6 +139,7 @@ class Game extends React.Component {
 
   willUpdateStateData(data) {
     return data.joining_players_count ||
+           data.joining_players ||
            data.showCardSelectionScreen ||
            data.button ||
            data.action_type === 'new_round_start'

--- a/src/components/sharedComponents/Alerts/GameStartAlert.jsx
+++ b/src/components/sharedComponents/Alerts/GameStartAlert.jsx
@@ -24,11 +24,7 @@ class GameStartAlert extends React.Component {
   }
 
   handlePassing() {
-    const { game_id, player_game_id } = this.state
-    requestPUTTo(
-      `http://localhost:3000/games/${game_id}/player_games/${player_game_id}`,
-      { player_is_active: false }
-    ).then(this.props.handleDismissAlert())
+    this.props.handleDismissAlert()
   }
 
   render() {

--- a/src/routes.js
+++ b/src/routes.js
@@ -44,7 +44,7 @@ export const routes = [
   },
   {
     exact: true,
-    path: '/games/:game_id/player_games/:id/edit',
+    path: '/games/:game_id/player_sessions/:id/edit',
     component: CardSelection
   }
 ];


### PR DESCRIPTION
Related: [Issue#95](https://github.com/arman-miranda/poker_plus_api/pull/107)
* add new function handleGameStateSetting() that would call
  handleCurrentSeatAssignments() and handleCurrentComCards() so that the UI
  would start fresh

* add new branching if on the socket that would capture the data with
  action_type 'new_round_start' and then call handleGameStateSetting() after
  setting the new data

* add new callback on the socket named reset_game_state that would be called
  when the game has ended, this would use the socket to call the
  reset_game_state method on the GameChannel that would send back new data.